### PR TITLE
minimega: cleanup vnc websocket tunnel

### DIFF
--- a/misc/web/js/glue.js
+++ b/misc/web/js/glue.js
@@ -55,7 +55,7 @@ function screenshotURL (vm, size) {
 
 // Generate the appropriate URL for requesting a VNC connection
 function vncURL (vm) {
-    return "./vnc#" + vm.host + ":" + (vm.vnc_port) + ":" + vm.name
+    return "./vnc#" + vm.name
 }
 
 // Get the screenshot for the requested row, or restore it from the cache of screenshots if available

--- a/misc/web/vnc_auto.html
+++ b/misc/web/vnc_auto.html
@@ -207,12 +207,9 @@
             }
 
             password = WebUtil.getConfigVar('password', '');
-            
-            // minimega: use value from template instead of URL
-            //path = WebUtil.getConfigVar('path', 'websockify');
-            var locationArray = window.location.hash.split(":");
-            //path = "ws/" + locationArray[0].substring(1) + "/" + locationArray[1];
-            path = "ws/" + locationArray[2];
+
+            // minimega: grab VM name from URL
+            path = "ws/" + window.location.hash.substring(1);
 
             // If a token variable is passed in, set the parameter in a cookie.
             // This is used by nova-novncproxy.

--- a/src/minimega/web.go
+++ b/src/minimega/web.go
@@ -16,6 +16,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"websocket"
 )
 
 const (
@@ -107,7 +108,7 @@ func webStart(port int, root string) {
 	mux.HandleFunc("/vms", webVMs)
 	mux.HandleFunc("/vnc/", webVNC)
 	mux.HandleFunc("/screenshot/", webScreenshot)
-	mux.HandleFunc("/ws/", vncWsHandler)
+	mux.Handle("/ws/", websocket.Handler(vncWsHandler))
 
 	if web.Server == nil {
 		web.Server = &http.Server{


### PR DESCRIPTION
Simplify the URL to be just the VM name. Remove the double copy of
remote -> ws after figuring out that there's an undocumented PayloadType
in websocket that must be set to BinaryFrame to use io.Copy.